### PR TITLE
Fixed bug, updated tests

### DIFF
--- a/takeoutthetrash-ui/src/js/Reducers/Cities/__tests__/index.test.js
+++ b/takeoutthetrash-ui/src/js/Reducers/Cities/__tests__/index.test.js
@@ -185,4 +185,27 @@ describe("cities reducer", () => {
     // Assert
     expect(result).toEqual(expectedState);
   });
+
+  test("when handling a PREFECTURE_SELECTED action should set fetchingCitySucceeded to false", () => {
+    // Arrange
+    const action = {
+      type: actionTypes.PREFECTURE_SELECTED,
+    };
+
+    const state = {
+      fetchingCitySucceeded: true,
+    };
+
+    deepFreeze(state);
+
+    const expectedState = {
+      fetchingCitySucceeded: false,
+    };
+
+    // Act
+    const result = sut(state, action);
+
+    // Assert
+    expect(result).toEqual(expectedState);
+  });
 });

--- a/takeoutthetrash-ui/src/js/Reducers/Cities/index.js
+++ b/takeoutthetrash-ui/src/js/Reducers/Cities/index.js
@@ -46,6 +46,11 @@ export default (state = initialState, action) => {
         fetchingCity: false,
         fetchingCityFailed: true,
       };
+    case actionTypes.PREFECTURE_SELECTED:
+      return {
+        ...state,
+        fetchingCitySucceeded: false,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
After selecting a prefecture and city the city's info is displayed. If a user then selects a new prefecture the same city's info continues to be displayed until a new city is selected. Fixed s that city disappears when new prefecture is selected.