### PR TITLE
Show Spinner On Fetch Rules

### DIFF
--- a/takeoutthetrash-ui/src/js/Actions/Feedback/__tests__/index.test.js
+++ b/takeoutthetrash-ui/src/js/Actions/Feedback/__tests__/index.test.js
@@ -119,7 +119,7 @@ describe("feedback action", () => {
       // Arrange
       const feedbackFormApiUrl = "feedbackFormApiUrl";
 
-      citiesSelectors.getCityId = jest
+      citiesSelectors.getSelectedCityId = jest
         .fn()
         .mockReturnValue(testData.cityWithRules.id);
 

--- a/takeoutthetrash-ui/src/js/Actions/Feedback/index.js
+++ b/takeoutthetrash-ui/src/js/Actions/Feedback/index.js
@@ -24,10 +24,10 @@ export const postFeedbackForm = () => async (dispatch, getState) => {
 
     const state = getState();
 
-    const cityId = citySelectors.getCityId(state);
+    const selectedCityId = citySelectors.getSelectedCityId(state).id;
     const feedbackFormValues = feedbackSelectors.getFeedbackFormValues(state);
 
-    const request = { cityId, feedbackFormValues };
+    const request = { selectedCityId, feedbackFormValues };
 
     const response = await fetch.postJson(url, request);
     if (response.ok) {

--- a/takeoutthetrash-ui/src/js/Components/Common/Header.js
+++ b/takeoutthetrash-ui/src/js/Components/Common/Header.js
@@ -35,7 +35,7 @@ const Header = ({ openFeedbackFormButtonClicked }) => {
 };
 
 Header.propTypes = {
-  openFeedbackFormButtonClicked: PropTypes.isRequired,
+  openFeedbackFormButtonClicked: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = {

--- a/takeoutthetrash-ui/src/js/Components/Common/SpinnerLegend.js
+++ b/takeoutthetrash-ui/src/js/Components/Common/SpinnerLegend.js
@@ -5,20 +5,33 @@ import * as prefecturesSelectors from "../../Selectors/Prefectures";
 import * as feedbackSelectors from "../../Selectors/Feedback";
 
 const getPrefectureName = (prefecture) => {
-  //show spinner when fetching rules for city
   if (prefecture.name === undefined) {
     return "selected prefecture";
   }
   return prefecture.name;
 };
 
+const getCityName = (prefecture, selectedCityId) => {
+  // selectedCityId should be a number, not a string. Think of a way to fix..
+  const city = prefecture.cities.find((x) => x.id === parseInt(selectedCityId));
+  if (city === undefined) {
+    return "selected city";
+  }
+  return city.name;
+};
+
 export const getSpinnerLegend = (
   isFetchingCities,
   prefecture,
-  isPostingFeedbackForm
+  isPostingFeedbackForm,
+  isFetchingCity,
+  selectedCityId
 ) => {
   if (isFetchingCities && prefecture) {
     return `Retrieving cities for ${getPrefectureName(prefecture)}`;
+  }
+  if (isFetchingCity) {
+    return `Retrieving rules for ${getCityName(prefecture, selectedCityId)}`;
   }
   if (isPostingFeedbackForm) {
     return "Posting feedback";
@@ -30,8 +43,16 @@ const SpinnerLegend = ({
   isFetchingCities,
   prefecture,
   isPostingFeedbackForm,
+  isFetchingCity,
+  selectedCityId,
 }) => {
-  return getSpinnerLegend(isFetchingCities, prefecture, isPostingFeedbackForm);
+  return getSpinnerLegend(
+    isFetchingCities,
+    prefecture,
+    isPostingFeedbackForm,
+    isFetchingCity,
+    selectedCityId
+  );
 };
 
 SpinnerLegend.propTypes = {
@@ -39,14 +60,32 @@ SpinnerLegend.propTypes = {
   prefecture: PropTypes.shape({
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
+    cities: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        rules: PropTypes.arrayOf(
+          PropTypes.shape({
+            name: PropTypes.string,
+            description: PropTypes.string,
+            instructions: PropTypes.string,
+            irregularFrequency: PropTypes.string,
+          })
+        ),
+      })
+    ),
   }),
   isPostingFeedbackForm: PropTypes.bool,
+  isFetchingCity: PropTypes.bool,
+  selectedCityId: PropTypes.number,
 };
 
 const mapStateToProps = (state) => ({
   isFetchingCities: citiesSelectors.isFetchingCities(state),
   prefecture: prefecturesSelectors.getPrefecture(state),
   isPostingFeedbackForm: feedbackSelectors.isPostingFeedbackForm(state),
+  isFetchingCity: citiesSelectors.isFetchingCity(state),
+  selectedCityId: citiesSelectors.getSelectedCityId(state),
 });
 
 export default connect(mapStateToProps)(SpinnerLegend);

--- a/takeoutthetrash-ui/src/js/Components/Common/__tests__/SpinnerLegend.test.js
+++ b/takeoutthetrash-ui/src/js/Components/Common/__tests__/SpinnerLegend.test.js
@@ -2,17 +2,19 @@ import * as sut from "../SpinnerLegend";
 import * as testData from "../../../CommonTestData/TestData";
 
 describe("getSpinnerLegend", () => {
-  test("should return null if isFetchingCities and isPostingFeedbackForm are false", () => {
+  test("should return null if isFetchingCities, isPostingFeedbackForm and isFetchingCity are false", () => {
     // Arrange
     const isFetchingCities = false;
     const isPostingFeedbackForm = false;
     const prefecture = {};
+    const isFetchingCity = false;
 
     // Act
     const result = sut.getSpinnerLegend(
       isFetchingCities,
       prefecture,
-      isPostingFeedbackForm
+      isPostingFeedbackForm,
+      isFetchingCity
     );
 
     //Assert
@@ -24,33 +26,79 @@ describe("getSpinnerLegend", () => {
     const isFetchingCities = true;
     const isPostingFeedbackForm = false;
     const prefecture = {};
+    const isFetchingCity = false;
 
     // Act
     const result = sut.getSpinnerLegend(
       isFetchingCities,
       prefecture,
-      isPostingFeedbackForm
+      isPostingFeedbackForm,
+      isFetchingCity
     );
 
     //Assert
     expect(result).toEqual("Retrieving cities for selected prefecture");
   });
 
-  test("should interpolate name of prefecture prefecture is populated in state", () => {
+  test("should interpolate name of prefecture if prefecture is populated in state", () => {
     // Arrange
     const isFetchingCities = true;
     const isPostingFeedbackForm = false;
     const prefecture = testData.arrayOfPrefectures[0];
+    const isFetchingCity = false;
 
     // Act
     const result = sut.getSpinnerLegend(
       isFetchingCities,
       prefecture,
-      isPostingFeedbackForm
+      isPostingFeedbackForm,
+      isFetchingCity
     );
 
     //Assert
     expect(result).toEqual("Retrieving cities for Aichi");
+  });
+
+  test("should return 'Retrieving rules for selected city' if isFetchingCities is true but selectedCityId is out of range", () => {
+    // Arrange
+    const isFetchingCities = false;
+    const isPostingFeedbackForm = false;
+    const prefecture = testData.prefectureWithCities;
+    const isFetchingCity = true;
+    const selectedCityId = 4;
+
+    // Act
+    const result = sut.getSpinnerLegend(
+      isFetchingCities,
+      prefecture,
+      isPostingFeedbackForm,
+      isFetchingCity,
+      selectedCityId
+    );
+
+    //Assert
+    expect(result).toEqual("Retrieving rules for selected city");
+  });
+
+  test("should interpolate name of city if city is populated in state", () => {
+    // Arrange
+    const isFetchingCities = false;
+    const isPostingFeedbackForm = false;
+    const prefecture = testData.prefectureWithCities;
+    const isFetchingCity = true;
+    const selectedCityId = 1;
+
+    // Act
+    const result = sut.getSpinnerLegend(
+      isFetchingCities,
+      prefecture,
+      isPostingFeedbackForm,
+      isFetchingCity,
+      selectedCityId
+    );
+
+    //Assert
+    expect(result).toEqual("Retrieving rules for Yokohama");
   });
 
   test("should return 'Posting feedback' if isPostingFeedbackForm: true", () => {
@@ -58,12 +106,14 @@ describe("getSpinnerLegend", () => {
     const isFetchingCities = false;
     const isPostingFeedbackForm = true;
     const prefecture = {};
+    const isFetchingCity = false;
 
     // Act
     const result = sut.getSpinnerLegend(
       isFetchingCities,
       prefecture,
-      isPostingFeedbackForm
+      isPostingFeedbackForm,
+      isFetchingCity
     );
 
     //Assert

--- a/takeoutthetrash-ui/src/js/Components/RulesDisplay.js
+++ b/takeoutthetrash-ui/src/js/Components/RulesDisplay.js
@@ -60,7 +60,7 @@ const RulesDisplay = ({
 
 RulesDisplay.propTypes = {
   openRulesModal: PropTypes.func.isRequired,
-  openFeedbackFormButtonClicked: PropTypes.isRequired,
+  openFeedbackFormButtonClicked: PropTypes.func.isRequired,
   fetchingCitySucceeded: PropTypes.bool.isRequired,
   city: PropTypes.shape({
     id: PropTypes.number,

--- a/takeoutthetrash-ui/src/js/Pages/LandingPage.js
+++ b/takeoutthetrash-ui/src/js/Pages/LandingPage.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import * as citiesSelectors from "../Selectors/Cities";
 
-const LandingPage = ({ isFetchingCities }) => {
+const LandingPage = ({ isFetchingCities, isFetchingCity }) => {
   return (
     <div className="container">
       <div className="landing-page">
@@ -17,7 +17,7 @@ const LandingPage = ({ isFetchingCities }) => {
         <h2>Do you know where you live???</h2>
         <SelectCityForm />
         <RulesDisplay />
-        <FetchingStateSpinner isVisible={isFetchingCities} />
+        <FetchingStateSpinner isVisible={isFetchingCities || isFetchingCity} />
       </div>
     </div>
   );
@@ -25,10 +25,12 @@ const LandingPage = ({ isFetchingCities }) => {
 
 LandingPage.propTypes = {
   isFetchingCities: PropTypes.bool,
+  isFetchingCity: PropTypes.bool,
 };
 
 const mapStateToProps = (state) => ({
   isFetchingCities: citiesSelectors.isFetchingCities(state),
+  isFetchingCity: citiesSelectors.isFetchingCity(state),
 });
 
 export default connect(mapStateToProps)(LandingPage);

--- a/takeoutthetrash-ui/src/js/Selectors/Cities/__tests__/index.test.js
+++ b/takeoutthetrash-ui/src/js/Selectors/Cities/__tests__/index.test.js
@@ -303,21 +303,4 @@ describe("cities selectors", () => {
       expect(result).toEqual(testData.cityWithRules);
     });
   });
-
-  describe("getCityId", () => {
-    test("when city is set selector should return id of selected city", () => {
-      // Arrange
-      const state = {
-        cities: {
-          city: testData.cityWithRules,
-        },
-      };
-
-      // Act
-      const result = sut.getCityId(state);
-
-      // Assert
-      expect(result).toEqual(testData.cityWithRules.id);
-    });
-  });
 });

--- a/takeoutthetrash-ui/src/js/Selectors/Cities/index.js
+++ b/takeoutthetrash-ui/src/js/Selectors/Cities/index.js
@@ -40,8 +40,3 @@ export const fetchingCityFailed = compose(
 );
 
 export const getCity = compose(defaultTo({}), prop("city"), getCitiesState);
-
-export const getCityId = (state) => {
-  const city = getCity(state);
-  return city.id;
-};


### PR DESCRIPTION
Display spinner when fetching city rules. Extract city name from prefectures by selectedCityId and interpolate into spinner legend. Test. General refactoring.