### PR TITLE
Stateful feedback page

### DIFF
--- a/takeoutthetrash-ui/src/js/Components/FeedbackForm.js
+++ b/takeoutthetrash-ui/src/js/Components/FeedbackForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { connect } from "react-redux";
 import * as feedbackActions from "../Actions/Feedback";
 import PropTypes from "prop-types";
@@ -7,8 +7,6 @@ import * as feedbackSelectors from "../Selectors/Feedback";
 import { TextInput, TEXT_AREA } from "../Components/Common/TextInput";
 import * as citiesSelectors from "../Selectors/Cities";
 import { isNilOrEmpty } from "../Utilities/RamdaUtilities";
-
-const COMMENT_MAX = 150;
 
 export const preventFormSubmission = (formValues, city, errors) => {
   return isNilOrEmpty(formValues.comment) ||
@@ -26,7 +24,7 @@ const EmailFormField = ({ visible, formValues, handleInputChange }) => {
     <TextInput
       name="email"
       value={formValues.email}
-      onChange={(e) => handleInputChange(e.target)}
+      onChange={handleInputChange}
       required={false}
       placeholder="Email"
     />
@@ -34,50 +32,23 @@ const EmailFormField = ({ visible, formValues, handleInputChange }) => {
 };
 
 const FeedbackForm = ({
-  postFeedbackForm,
-  feedbackFormValuesUpdated,
   toggledEnableEmailFormField,
   emailFormFieldEnabled,
   city,
+  onChange,
+  formValues,
+  onSubmit,
+  errors,
 }) => {
-  let [formValues, setFormValues] = useState({ comment: "", email: "" });
-  let [errors, setErrors] = useState({});
-
-  const formIsValid = () => {
-    const _errors = {};
-
-    if (formValues.comment.length >= COMMENT_MAX)
-      _errors.comment = `Maximum ${COMMENT_MAX} characters`;
-    //regex validation for email address
-    setErrors(_errors);
-
-    return Object.keys(_errors).length === 0;
-  };
-
-  const handleInputChange = (target) => {
-    const updatedFormValues = {
-      ...formValues,
-      [target.name]: target.value,
-    };
-    setFormValues(updatedFormValues);
-    feedbackFormValuesUpdated(updatedFormValues);
-    if (!formIsValid()) return;
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    postFeedbackForm();
-  };
-
-  const disableSubmitButton = preventFormSubmission(formValues, city, errors);
+  //const disableSubmitButton = preventFormSubmission(formValues, city, errors);
 
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={onSubmit}>
         <TextInput
           name={"comment"}
           value={formValues.comment}
-          onChange={(e) => handleInputChange(e.target)}
+          onChange={onChange}
           required={true}
           placeholder="Comment"
           error={errors.comment}
@@ -95,13 +66,13 @@ const FeedbackForm = ({
         <EmailFormField
           visible={emailFormFieldEnabled}
           formValues={formValues}
-          handleInputChange={handleInputChange}
+          handleInputChange={onChange}
         />
         <div className="feedback-submit-button">
           <button
             type="submit"
             className="submit-button"
-            disabled={disableSubmitButton}
+            //disabled={disableSubmitButton}
           >
             Submit
           </button>
@@ -112,14 +83,22 @@ const FeedbackForm = ({
 };
 
 FeedbackForm.propTypes = {
-  feedbackFormValuesUpdated: PropTypes.func.isRequired,
-  postFeedbackForm: PropTypes.func.isRequired,
   toggledEnableEmailFormField: PropTypes.func.isRequired,
   emailFormFieldEnabled: PropTypes.bool,
   city: PropTypes.shape({
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
     rules: PropTypes.arrayOf(PropTypes.object),
+  }),
+  onChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  formValues: PropTypes.shape({
+    comment: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  errors: PropTypes.shape({
+    comment: PropTypes.string,
+    email: PropTypes.string,
   }),
 };
 
@@ -129,8 +108,6 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = {
-  feedbackFormValuesUpdated: feedbackActions.feedbackFormValuesUpdated,
-  postFeedbackForm: feedbackActions.postFeedbackForm,
   toggledEnableEmailFormField: feedbackActions.enableEmailFormFieldToggled,
 };
 

--- a/takeoutthetrash-ui/src/js/Pages/Feedback.js
+++ b/takeoutthetrash-ui/src/js/Pages/Feedback.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import SelectCityForm from "../Components/SelectCityForm";
 import FeedbackForm from "../Components/FeedbackForm";
 import FetchingStateSpinner from "../Components/Common/FetchingStateSpinner";
@@ -9,6 +9,9 @@ import { Link } from "react-router-dom";
 import FeedbackPageLegend from "../Components/FeedbackPageLegend";
 import * as homeActions from "../Actions/Home";
 import * as citiesSelectors from "../Selectors/Cities";
+import * as feedbackActions from "../Actions/Feedback";
+
+const COMMENT_MAX = 150;
 
 const Feedback = ({
   postingFeedbackFormSucceeded,
@@ -18,7 +21,39 @@ const Feedback = ({
   openHomePageButtonClicked,
   isFetchingCities,
   isFetchingCity,
+  feedbackFormValuesUpdated,
+  postFeedbackForm,
 }) => {
+  let [formValues, setFormValues] = useState({ comment: "", email: "" });
+  let [errors, setErrors] = useState({});
+
+  const validateOnChange = () => {
+    const _errors = {};
+
+    if (formValues.comment.length >= COMMENT_MAX)
+      _errors.comment = `Maximum ${COMMENT_MAX} characters`;
+    //regex validation for email address
+    setErrors(_errors);
+
+    return Object.keys(_errors).length === 0;
+  };
+
+  const handleInputChange = ({ target }) => {
+    console.log(target.value);
+    const updatedFormValues = {
+      ...formValues,
+      [target.name]: target.value,
+    };
+    setFormValues(updatedFormValues);
+    feedbackFormValuesUpdated(updatedFormValues);
+    validateOnChange();
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    postFeedbackForm();
+  };
+
   if (postingFeedbackFormSucceeded || displayRetryFailureMessage) {
     return (
       <div className="container">
@@ -44,7 +79,12 @@ const Feedback = ({
       <div className="landing-page">
         <h2>Feedback Form</h2>
         <SelectCityForm />
-        <FeedbackForm />
+        <FeedbackForm
+          onChange={handleInputChange}
+          onSubmit={handleSubmit}
+          formValues={formValues}
+          errors={errors}
+        />
         <FetchingStateSpinner
           isVisible={
             isPostingFeedbackForm ||
@@ -65,10 +105,13 @@ Feedback.propTypes = {
   openHomePageButtonClicked: PropTypes.func.isRequired,
   isFetchingCities: PropTypes.bool,
   isFetchingCity: PropTypes.bool,
+  postFeedbackForm: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = {
   openHomePageButtonClicked: homeActions.openHomePageButtonClicked,
+  feedbackFormValuesUpdated: feedbackActions.feedbackFormValuesUpdated,
+  postFeedbackForm: feedbackActions.postFeedbackForm,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
Moved some logic from the feedbackform to the feedback page so that it (error handling) can be shared between the feedbackform and the select city form on the feedback page.